### PR TITLE
Add useragent feature

### DIFF
--- a/cmd/goop.go
+++ b/cmd/goop.go
@@ -11,6 +11,7 @@ import (
 var force bool
 var keep bool
 var list bool
+var useragent string
 var rootCmd = &cobra.Command{
 	Use:   "goop",
 	Short: "goop is a very fast tool to grab sources from exposed .git folders",
@@ -21,12 +22,12 @@ var rootCmd = &cobra.Command{
 			dir = args[1]
 		}
 		if list {
-			if err := goop.CloneList(args[0], dir, force, keep); err != nil {
+			if err := goop.CloneList(args[0], dir, force, keep, useragent); err != nil {
 				log.Error().Err(err).Msg("exiting")
 				os.Exit(1)
 			}
 		} else {
-			if err := goop.Clone(args[0], dir, force, keep); err != nil {
+			if err := goop.Clone(args[0], dir, force, keep, useragent); err != nil {
 				log.Error().Err(err).Msg("exiting")
 				os.Exit(1)
 			}
@@ -38,6 +39,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&force, "force", "f", false, "overrides DIR if it already exists")
 	rootCmd.PersistentFlags().BoolVarP(&keep, "keep", "k", false, "keeps already downloaded files in DIR, useful if you keep being ratelimited by server")
 	rootCmd.PersistentFlags().BoolVarP(&list, "list", "l", false, "allows you to supply the name of a file containing a list of domain names instead of just one domain")
+	rootCmd.PersistentFlags().StringVarP(&useragent, "useragent", "u", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36", "allows you to change the default User-Agent")
 }
 
 func Execute() {


### PR DESCRIPTION
Adds the feature of changing your User-Agent to whatever you want.

I added the command `-u` or `--useragent` inside **goop.go** and a new method called `CustomUE` inside **clone.go** to check if the variable `useragent` is empty or not, basically encapsulating `c` variable body inside a function.

I think it would be neat to have this bc being able to change your user agent while enumerating a remote server gives you a lot more power by obfuscating your identity.